### PR TITLE
 BaSP-MR-21: create get and post test for "class"

### DIFF
--- a/src/controllers/class.js
+++ b/src/controllers/class.js
@@ -34,7 +34,7 @@ const getClassById = (req, res) => {
       data: classId,
       error: false,
     }))
-    .catch((error) => res.json({
+    .catch((error) => res.status(404).json({
       message: 'An error ocurred',
       error,
     }));

--- a/src/tests/classes.test.js
+++ b/src/tests/classes.test.js
@@ -8,6 +8,68 @@ beforeAll(async () => {
   await Class.collection.insertMany(classSeed);
 });
 
+const mockClass = {
+  activity: '6465286dad795d0bf31704f1',
+  trainer: ['6460763768fd665d7bf97f13', '646076aa68fd665d7bf97f1b'],
+  day: 'Tuesday',
+  time: '20:00',
+  capacity: 20,
+};
+describe('GET all class /api/class', () => {
+  test('should return status 200', async () => {
+    const response = await request(app).get('/api/class/search').send();
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('should return status 200', async () => {
+    const response = await request(app).get('/api/class/search/?day=Monday');
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('should return status 404', async () => {
+    const response = await request(app).get('/api/class').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+});
+
+describe('Create class /api/class/', () => {
+  test('Should create a class with status 201', async () => {
+    const response = await request(app).post('/api/class').send(mockClass);
+    expect(response.status).toBe(201);
+    expect(response.error).toBeFalsy();
+    expect(response.body).toBeDefined();
+    expect(response.body.trainer).toBeDefined();
+    expect(response.body.activity).toBeDefined();
+    expect(response.body.day).toBeDefined();
+    expect(response.body.time).toBeDefined();
+    expect(response.body.capacity).toBeDefined();
+  });
+  test('should return status 404', async () => {
+    const response = await request(app).post('/api/classs').send(mockClass);
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+});
+
+describe('GET class by ID /api/class/:id', () => {
+  test('should return status 200', async () => {
+    const response = await request(app).get('/api/class/6462ea9abb5168b3bbbc8bc0');
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('should return an existing class', async () => {
+    const response = await request(app).get('/api/class/6462ea9abb5168b3bbbc8bc0').send();
+    const classId = response.body.data;
+    expect(classId).toBeDefined();
+  });
+  test('should return status 404', async () => {
+    const response = await request(app).get('/api/class/12312212312312212').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+});
+
 describe('PUT logic delete by id api/class/delete/:id', () => {
   test('on good request return status 200 - "delete" property change false for true', async () => {
     const response = await request(app).put(`/api/class/delete/${classSeed[0]._id}`).send();


### PR DESCRIPTION
Added tests for POST and GET methods in 'class'. These tests ensure functionality and reliability, covering various scenarios and edge cases. Enhances code quality and stability.