### PR TITLE
BaSP-MR-198: fixed required subscribed property

### DIFF
--- a/src/validations/class.js
+++ b/src/validations/class.js
@@ -8,7 +8,7 @@ const validateCreation = (req, res, next) => {
     time: Joi.string().regex(/^([0-9]|[01]\d|2[0-3]):([00]\d)$/).required(),
     capacity: Joi.number().min(1).max(50).required()
       .integer(),
-    subscribed: Joi.number().min(0).max(50).integer().required(),
+    subscribed: Joi.number().min(0).max(50).integer(),
 
   });
 


### PR DESCRIPTION
Subscribed property shouldn't be required because is set in the server